### PR TITLE
Added field to song info for image alt text, updated db and tests accordingly

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -68,6 +68,6 @@ class SongsController < ApplicationController
   private 
   
   def song_params
-    params.require(:song).permit(:artist, :title, :pic, :audio, :video, :subhead, :status)
+    params.require(:song).permit(:artist, :title, :pic, :alttext, :audio, :video, :subhead, :status)
   end
 end

--- a/app/services/formatter_service.rb
+++ b/app/services/formatter_service.rb
@@ -6,7 +6,8 @@ class FormatterService
   end
   
   def self.generate_post_frame(song, subhead, image_link)
-    post_html = "<p><i>#{subhead}</i></p><center><img src= '#{image_link}' alt = '#{song.artist} - #{song.title}' border = 2><br><b>[<a href='#{song.video}'>Video</a>]"
+    alt = song.alttext ? song.alttext : "#{song.artist} - #{song.title}"
+    post_html = "<p><i>#{subhead}</i></p><center><img src= '#{image_link}' alt = '#{alt}' border = 2><br><b>[<a href='#{song.video}'>Video</a>]"
     post_html += "<BR><a title='Controversy index: #{sprintf('%.2f', song.controversy)}'>[#{sprintf('%.2f', song.score)}]</a></b></center></p>"
   end
 

--- a/app/views/songs/edit.html.erb
+++ b/app/views/songs/edit.html.erb
@@ -17,6 +17,11 @@
   </div>
 
   <div>
+    <%= form.label "Alt text" %>  
+    <%= form.text_field :alttext %>
+  </div>
+  
+  <div>
     <%= form.label :audio %><br>
     <%= form.text_field :audio %>
   </div>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -34,6 +34,9 @@
 <% else %>
   <h3>[No picture yet!]</h3>
 <% end %>
+<% if policy(Song).edit? %>
+  Image alt text: <%= @song.alttext ? @song.alttext : @song.artist + " - " +  @song.title %>
+<% end %>
 <h4>
   <% if @song.audio && @song.audio != "" %>
     [<a href="<%= @song.audio %>" target="_blank">Listen</a>]

--- a/db/migrate/20240212215520_add_alttext_to_songs.rb
+++ b/db/migrate/20240212215520_add_alttext_to_songs.rb
@@ -1,0 +1,5 @@
+class AddAlttextToSongs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :songs, :alttext, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_30_161540) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_12_215520) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -80,6 +80,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_30_161540) do
     t.datetime "updated_at", null: false
     t.decimal "score"
     t.decimal "controversy"
+    t.string "alttext"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/services/formatter_test.rb
+++ b/test/services/formatter_test.rb
@@ -11,6 +11,14 @@ class FormatterTest < ActiveSupport::TestCase
   end
   
   test "standard post frame is generated correctly" do
+    song = Song.create(title: "4 Ever", artist: "The Veronicas", alttext: "a real image", video: "https://youtube.com", score: 8, controversy: 0.55, status: "closed")
+    stripped_subhead = "we did this already"
+    image_link = "some url"
+    expected_frame = "<p><i>we did this already</i></p><center><img src= 'some url' alt = 'a real image' border = 2><br><b>[<a href='https://youtube.com'>Video</a>]<BR><a title='Controversy index: 0.55'>[8.00]</a></b></center></p>"
+    assert_equal(expected_frame, FormatterService.generate_post_frame(song, stripped_subhead, image_link))
+  end  
+
+  test "post frame for song without alt text is generated with default alt text" do
     song = Song.create(title: "4 Ever", artist: "The Veronicas", video: "https://youtube.com", score: 8, controversy: 0.55, status: "closed")
     stripped_subhead = "we did this already"
     image_link = "some url"


### PR DESCRIPTION
Alt text defaults to "artist - title" if none is specified.

Alt text can be entered regardless of whether an image is in the blurber since we are currently doing images manually anyway.