### PR TITLE
Added inline editing of reviews from song page

### DIFF
--- a/app/helpers/reviews_helper.rb
+++ b/app/helpers/reviews_helper.rb
@@ -1,2 +1,6 @@
 module ReviewsHelper
+  def inline_review_edit?
+    referrer = Rails.application.routes.recognize_path(request.referrer) 
+	referrer[:controller] == "songs" && referrer[:action] == "show"
+  end
 end

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,9 +1,7 @@
-<h2><%= song.artist %> - <%= song.title %></h2>
-
-<%= form_with model: [song, review] do |form| %>
+<%= form_with model: [@review] do |form| %>
   <div>
     <%= form.label :score %><br>
-    <%= form.select :score, options_for_select(0...11) %>
+    <%= form.select :score, (0...11) %>
   </div>
 
   <div>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,25 +1,16 @@
-<h2>Edit <%= @review.user.name %>'s review</h2>
-<h3>
+<% if inline_review_edit? %>
+  <%= turbo_frame_tag "review_#{@review.id}" do %>
+    <%= render "form", review: @review %>
+  <% end %>
+<% else %>
+  <h2>Edit <%= @review.user.name %>'s review</h2>
+  <h3>
     <%= @song.artist %> - <%= @song.title %>
     <% if current_user.writer? %>
       (<%= link_to "Go back", root_path %>)
     <% else %>
       (<%= link_to "Go back", @song %>)
     <% end %>
-</h3>
-
-<%= form_with model: [@review] do |form| %>
-  <div>
-    <%= form.label :score %><br>
-    <%= form.select :score, (0...11) %>
-  </div>
-
-  <div>
-    <%= form.label :content %>
-    <%= form.rich_text_area :content %>
-  </div>
-
-  <div>
-    <%= form.submit %>
-  </div>
+  </h3>
+  <%= render "form", review: @review %>
 <% end %>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -51,20 +51,23 @@
 <% else %>
   <ul data-controller="sortable">
     <%  @song.reviews.each do |review| %>
-      <li data-id ="<%= review.id %>">
-        <strong><a href="<%= review.user.url %>" target="_blank"><%= review.user.name %>:</strong></a> <%= sanitize review.content %>
-        [<%= review.score %>]<br>
-        <% if policy(review).edit? %>
-          (<%= link_to "Edit this review", edit_review_path(review) %>)
-        <% end %>
-        <% if policy(review).destroy? %>
-          (<%= link_to "Delete this review", review_path(review), :method => :delete, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %>)
-        <% end %>
-        <% if policy(User).show? %>
-          (<%= link_to "All #{review.user.name} blurbs", user_path(review.user) %>)
-        <% end %>
-      </li>
-    <% end %>
+        <li data-id ="<%= review.id %>">
+	        <%= turbo_frame_tag "review_#{review.id}", target: "_top" do %>
+              <strong><a href="<%= review.user.url %>" target="_blank"><%= review.user.name %>:</strong></a> <%= sanitize review.content %>
+            <% end %>
+		  <div class="review"></div>
+          [<%= review.score %>]<br>
+          <% if policy(review).edit? %>
+			  (<%= link_to "Edit this review", edit_review_path(review), data: { turbo_frame: dom_id(review) } %>)
+         <% end %>
+          <% if policy(review).destroy? %>
+            (<%= link_to "Delete this review", review_path(review), :method => :delete, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %>)
+          <% end %>
+          <% if policy(User).show? %>
+            (<%= link_to "All #{review.user.name} blurbs", user_path(review.user) %>)
+          <% end %>
+        </li>
+  <% end %>
   </ul>
 <% end %>
  


### PR DESCRIPTION
Currently this does not turn off drag-and-drop reordering, may be changed in the future if editors find that more annoying than helpful, and/or if I put drag-and-drop behind a toggle