### PR TITLE
KS: Filter for unpublished blurbs on User page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,15 @@ class UsersController < ApplicationController
   
   def show
     @user = User.find(params[:id])
-    @reviews = Review.includes(:song, :user).where(user_id: params[:id])
+    # TODO Should probably put some validation here but ehhh
+    @unpublished_only = request.query_parameters['unpublished_only']
+
+    if @unpublished_only
+      @reviews = Review.includes(:song, :user).where(user_id: params[:id]).joins(:song).where(song: {status: Song.statuses['open']})
+    else
+      @reviews = Review.includes(:song, :user).where(user_id: params[:id])
+    end
+
     if @user != current_user
       authorize User
     end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,11 @@
   <h3>Blurbs by <%= @user.name %></h3>
+  <p class="show_unpublished_link">
+      <% if @unpublished_only %>
+        <%= link_to "Show all reviews", user_path(current_user) %>
+      <% else %>
+        <%= link_to "Show unpublished reviews only", user_path(current_user, unpublished_only: "true") %>
+      <% end %>
+  </p>
   <% if @reviews.empty? %>
     <p>No reviews yet!</p>
   <% else %>

--- a/test/controllers/songs_controller_test.rb
+++ b/test/controllers/songs_controller_test.rb
@@ -48,4 +48,19 @@ class SongsControllerTest < ActionDispatch::IntegrationTest
     get new_song_path
     assert_redirected_to '/users/sign_in'
   end
+
+  test "admin can see song details" do
+    sign_in users(:bob)
+    @song = Song.find_by(title: "Everything Is Embarrassing")
+    assert @song.pic.attached?  # Fixture should have a corresponding sky.jpeg blob
+
+    get song_path(@song.id)
+
+    assert_response :success
+
+    assert_select "h2", text: "Sky Ferreira - Everything Is Embarrassing"
+    assert_select "button", text: "Reopen song", count: 1
+    assert_select "button", text: "Edit song info", count: 1
+    assert_select "img", count: 1
+  end
 end

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -14,6 +14,7 @@ class UserControllerTest < ActionDispatch::IntegrationTest
     # Both reviews should be visible
     assert_select "strong", text: "Boney M - Rasputin"
     assert_select "strong", text: "Wombo - Slab"
+    assert_select "strong", text: "Sky Ferreira - Everything Is Embarrassing"
   end
 
   test "unpublished reviews only if query param present " do
@@ -24,8 +25,19 @@ class UserControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_select "p.show_unpublished_link", "Show all reviews"
-    # Should only be 1 review visible as Slab is 'closed'
+    # Should only be 1 review visible as Slab and Sky are closed/published
     assert_select "strong", text: "Boney M - Rasputin"
     assert_select "strong", text: "Wombo - Slab", count: 0
+    assert_select "strong", text: "Sky Ferreira - Everything Is Embarrassing", count: 0
+  end
+
+  test "published reviews appear by default but do not show edit link" do
+    sign_in users(:alice)
+    @user = User.first
+
+    get user_path(@user.id)
+
+    assert_select "strong", text: "Sky Ferreira - Everything Is Embarrassing"
+    assert_select "a", text: "Edit", count: 2
   end
 end

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -1,7 +1,31 @@
 require "test_helper"
 
 class UserControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  include Devise::Test::IntegrationHelpers
+
+  test "all reviews shown for a user by default" do
+    sign_in users(:alice)
+    @user = User.first
+
+    get user_path(@user.id)
+    assert_response :success
+
+    assert_select "p.show_unpublished_link", "Show unpublished reviews only"
+    # Both reviews should be visible
+    assert_select "strong", text: "Boney M - Rasputin"
+    assert_select "strong", text: "Wombo - Slab"
+  end
+
+  test "unpublished reviews only if query param present " do
+    sign_in users(:alice)
+    @user = User.first
+
+    get user_path(@user.id, unpublished_only: "true")
+    assert_response :success
+
+    assert_select "p.show_unpublished_link", "Show all reviews"
+    # Should only be 1 review visible as Slab is 'closed'
+    assert_select "strong", text: "Boney M - Rasputin"
+    assert_select "strong", text: "Wombo - Slab", count: 0
+  end
 end

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -1,0 +1,4 @@
+embarrassing_pic:
+  name: pic
+  record: embarrassing (Song)
+  blob: sky_pic_blob

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -1,0 +1,1 @@
+sky_pic_blob:  <%= ActiveStorage::FixtureSet.blob filename: "sky.jpeg", service_name: 'test' %>                                                                               

--- a/test/fixtures/reviews.yml
+++ b/test/fixtures/reviews.yml
@@ -13,3 +13,10 @@ review2:
   score: 1
   song: rasputin
   user: alice
+
+review3:
+  content: MyString
+  rich_text: MyString
+  score: 1
+  song: slab
+  user: alice

--- a/test/fixtures/reviews.yml
+++ b/test/fixtures/reviews.yml
@@ -20,3 +20,10 @@ review3:
   score: 1
   song: slab
   user: alice
+
+review4:
+  content: MyString
+  rich_text: MyString
+  score: 10
+  song: embarrassing
+  user: alice

--- a/test/fixtures/songs.yml
+++ b/test/fixtures/songs.yml
@@ -9,3 +9,8 @@ rasputin:
   title: "Rasputin"
   artist: "Boney M"
   status: "open"
+
+slab:
+  title: "Slab"
+  artist: "Wombo"
+  status: "closed"

--- a/test/fixtures/songs.yml
+++ b/test/fixtures/songs.yml
@@ -14,3 +14,8 @@ slab:
   title: "Slab"
   artist: "Wombo"
   status: "closed"
+
+embarrassing:
+  title: "Everything Is Embarrassing"
+  artist: "Sky Ferreira"
+  status: "published"


### PR DESCRIPTION
Adds a link to the User page to filter for 'open' songs only, using a query string. 

I've gone for only showing Open songs rather than delving into the grey area of closed-but-not-yet-published, to try and avoid confusion for writers. Feel free to amend the filter/wording if you want!

Also adds some more tests for song viewing and editing.
