### PR TITLE
Adds a button to manually generate post HTML

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+import { FetchRequest } from '@rails/request.js'
+
+export default class extends Controller {
+	
+  static targets = [ "button" ];	
+  async copy_html(event) {
+    event.preventDefault();
+    this.buttonTarget.innerText = "Copied!";
+    navigator.clipboard.writeText(event.params.html);
+  }
+}

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -2,8 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 import { FetchRequest } from '@rails/request.js'
 
 export default class extends Controller {
-	
-  static targets = [ "button" ];	
+  
+  static targets = [ "button" ];  
   async copy_html(event) {
     event.preventDefault();
     this.buttonTarget.innerText = "Copied!";

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -67,7 +67,7 @@ class Song < ApplicationRecord
     unless self.schedule_wp(time, title, stripped_subhead, html, current_user)
       return false
     end
-	true
+    true
   end
 
   private  
@@ -77,9 +77,9 @@ class Song < ApplicationRecord
   end
 
   def self.schedule_wp(time, title, subhead, html, current_user)
-      #true
-      res = WordpressService.create_post(time, title, subhead, html, current_user)
-	  p res
-      res && res.code == "201"
+    #true
+    res = WordpressService.create_post(time, title, subhead, html, current_user)
+    p res
+    res && res.code == "201"
   end 
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -51,11 +51,18 @@ class Song < ApplicationRecord
     self.save
   end
   
+  def generate_html
+    stripped_subhead = FormatterService.strip_subhead(self.subhead)
+    image_link = self.image_url
+    post_html = FormatterService.generate_post_frame(self, stripped_subhead, image_link)
+    self.reviews.each { |review| post_html += FormatterService.generate_review(review)  }
+    post_html
+  end
+  
   def self.schedule_post!(song, time, current_user)
     time = time.to_time(:utc).iso8601
     stripped_subhead = FormatterService.strip_subhead(song.subhead)
-    image_link = song.pic.attached? ? TEMP_IMAGE_HOST + Rails.application.routes.url_helpers.rails_blob_path(song.pic, only_path: true) : ""
-    html = self.generate_html(song, stripped_subhead, image_link)
+    html = song.generate_html
     title = "#{song.artist} - #{song.title}"
     unless self.schedule_wp(time, title, stripped_subhead, html, current_user)
       return false
@@ -65,17 +72,14 @@ class Song < ApplicationRecord
 
   private  
   
-  def self.generate_html(song, subhead, image_link)
-    post_html = FormatterService.generate_post_frame(song, subhead, image_link)
-    song.reviews.each { |review| post_html += FormatterService.generate_review(review)  }
-    post_html
+  def image_url
+    self.pic.attached? ? TEMP_IMAGE_HOST + Rails.application.routes.url_helpers.rails_blob_path(self.pic, only_path: true) : ""
   end
 
   def self.schedule_wp(time, title, subhead, html, current_user)
       #true
       res = WordpressService.create_post(time, title, subhead, html, current_user)
 	  p res
-	  p res.code
       res && res.code == "201"
   end 
 end

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -21,6 +21,9 @@
           <%= form.button "Post" %>
         </div>
      <% end %>
+	 <div data-controller="clipboard">
+       <button data-action="click->clipboard#copy_html" data-clipboard-target="button" data-clipboard-html-param="<%= @song.generate_html %>">Copy post HTML</button>
+	 </div>
   <% else %>
     <%= button_to "Reopen song", song_path(song: { status: "open" }), { method: :patch, form: { data: { turbo: true } } } %>    
   <% end %>
@@ -35,7 +38,7 @@
   <h3>[No picture yet!]</h3>
 <% end %>
 <% if policy(Song).edit? %>
-  Image alt text: <%= @song.alttext ? @song.alttext : @song.artist + " - " +  @song.title %>
+  <p>Image alt text: <%= @song.alttext ? @song.alttext : @song.artist + " - " +  @song.title %></p>
 <% end %>
 <h4>
   <% if @song.audio && @song.audio != "" %>

--- a/test/models/song_test.rb
+++ b/test/models/song_test.rb
@@ -79,11 +79,11 @@ class CollateBlurbTest < ActiveSupport::TestCase
   include Rails.application.routes.url_helpers
   test "song with no reviews or image just has an html post with the header" do
     song = Song.create(title: "India In Me", artist: "Cobblestone Jazz", status: "open", video: "https://youtube.com", score: 0, controversy: 0, reviews: [])
-    subhead = "Banger from Ellen Allien Fabric mix"
+    song.subhead = "<div>Banger from Ellen Allien Fabric mix</div>"
     image_link = ""
 
     expected_header = "<p><i>Banger from Ellen Allien Fabric mix</i></p><center><img src= '' alt = 'Cobblestone Jazz - India In Me' border = 2><br><b>[<a href='https://youtube.com'>Video</a>]<BR><a title='Controversy index: 0.00'>[0.00]</a></b></center></p>"
-    assert_equal(expected_header, Song.generate_html(song, subhead, image_link))
+    assert_equal(expected_header, song.generate_html)
   end
 
   test "song with reviews generates html blurb" do
@@ -93,7 +93,7 @@ class CollateBlurbTest < ActiveSupport::TestCase
     # User Jane doesn't have a website
     user2 = User.create!(username: "janeausten", name: "Jane Austen", password_confirmation: "whatevs")
     review2 = Review.create(song_id: song.id, user_id: user2.id, score: 8, content: "<div>Love it</div>")
-    subhead = "In which Justine fixes her laundry hanger"
+    song.subhead = "<div>In which Justine fixes her laundry hanger</div>"
     song.reviews = [review1, review2]
     image_link = ""
 
@@ -102,6 +102,6 @@ class CollateBlurbTest < ActiveSupport::TestCase
     expected_blurb2 = "<p><strong>Jane Austen:</strong> Love it<br>[8]</p>"
 
     expected_post = expected_header + expected_blurb1 + expected_blurb2
-    assert_equal(expected_post, Song.generate_html(song, subhead, image_link))
+    assert_equal(expected_post, song.generate_html)
   end
 end


### PR DESCRIPTION
This is a stopgap until the issue with WordPress API requests occasionally succeeding but not creating posts (successfully created posts produce a 201 response, we get 200) is resolved. It also makes crossposting to Tumblr easier (Cohost crossposting will require more UI work the way it is currently being done)

Related changes:
- Refactors the Song model slightly -- generating HTML is now in the public interface and producing the image URL is now not (which it probably shouldn't have been). 
- Updates unit tests for the Song model accordingly.

Todo:
- Check when exactly `generate_html` is called i.e. whether it is upon page load or upon pressing the button
- Add formatting/pretty-printing to the generated HTML so it is more human readable
- Check cross-browser compatibility, particularly on mobile and particularly on Safari