### PR TITLE
Creates review scopes for open/unpublished reviews

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,9 +12,9 @@ class UsersController < ApplicationController
     @unpublished_only = request.query_parameters['unpublished_only']
 
     if @unpublished_only
-      @reviews = Review.includes(:song, :user).where(user_id: params[:id]).joins(:song).where(song: {status: Song.statuses['open']})
+      @reviews = Review.all_open.by_user(params[:id])
     else
-      @reviews = Review.includes(:song, :user).where(user_id: params[:id])
+      @reviews = Review.by_user(params[:id])
     end
 
     if @user != current_user

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -8,7 +8,9 @@ class Review < ApplicationRecord
   
   default_scope { order(position: :asc) }
   scope :all_unpublished, -> { includes(:song, :user).where("songs.status != 2").references(:songs).by_created }
+  scope :all_open, -> { includes(:song, :user).where("songs.status = 0").references(:songs).by_created }
   scope :by_created, -> { reorder(created_at: :asc) }
+  scope :by_user, -> id { includes(:song, :user).where(user_id: id) }
 
   def url_present?
     return self.url.present?

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,7 +16,7 @@
 	    <tr>
           <td><%= account.id %></td>
 		  <td><%= account.name %></td>
-		  <td>[Pending] [<%= link_to "All", user_path(account) %>]</td>
+		  <td>[<%= link_to "Pending", user_path(account, unpublished_only: "true") %>] [<%= link_to "All", user_path(account) %>]</td>
 		  <td><a href="<%= account.url %>" target="_blank">Link</a></td>
       </tr>
 	<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,9 +1,9 @@
   <h3>Blurbs by <%= @user.name %></h3>
   <p class="show_unpublished_link">
       <% if @unpublished_only %>
-        <%= link_to "Show all reviews", user_path(current_user) %>
+        <%= link_to "Show all reviews", user_path(@user) %>
       <% else %>
-        <%= link_to "Show unpublished reviews only", user_path(current_user, unpublished_only: "true") %>
+        <%= link_to "Show unpublished reviews only", user_path(@user, unpublished_only: "true") %>
       <% end %>
   </p>
   <% if @reviews.empty? %>

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -1,7 +1,35 @@
 require "test_helper"
 
 class ReviewTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  def setup
+    @user1 = User.create!(username: "selena", name: "Selena Gomez", url: "thesinglesjukebox.com", password_confirmation: "badliar")
+    @user2 = User.create!(username: "carly", name: "Carly Rae Jepsen", url: "", password_confirmation: "tinylittlebows") 
+    @song1 = Song.create!(title: "Training Season", artist: "Dua Lipa", status: "open", video: "", score: 0, controversy: 0)
+    @song2 = Song.create!(title: "Houdini", artist: "Dua Lipa", status: "closed", video: "", score: 0, controversy: 0)
+    @song3 = Song.create!(title: "New Rules", artist: "Dua Lipa", status: "published", video: "", score: 0, controversy: 0)
+    @review1 = Review.create!(song_id: @song1.id, user_id: @user1.id, score: 0, content: "<div>i ended training season, it was me</div>")    
+    @review2 = Review.create!(song_id: @song2.id, user_id: @user1.id, score: 10, content: "<div>it's [10] season now</div>")    
+    @review3 = Review.create!(song_id: @song3.id, user_id: @user1.id, score: 1, content: "<div>don't pick up the phone</div>")
+    @review4 = Review.create!(song_id: @song1.id, user_id: @user2.id, score: 9, content: "<div>so relatable</div>")    
+  end
+  
+  test "unpublished review scope only includes reviews for open and closed songs" do
+    test_reviews = Review.where(id: [@review1.id, @review2.id, @review3.id])
+    reviews = test_reviews.all_unpublished
+    assert_equal(2, reviews.count)
+  end
+
+  test "open review scope only includes reviews for open songs" do
+    test_reviews = Review.where(id: [@review1.id, @review2.id, @review3.id])
+    reviews = test_reviews.all_open
+    assert_equal(1, reviews.count)
+  end
+  
+  test "reviews by user scope only includes reviews by specified user" do
+    test_reviews = Review.where(id: [@review1.id, @review4.id])
+    reviews = test_reviews.by_user(@user2.id)
+    assert_equal(1, reviews.count)
+  end
+
 end


### PR DESCRIPTION
- Added scopes to the Review model for open and unpublished songs 
- The [Pending] link on the user index page now actually links to a user's open songs.
- Fixes "Show unpublished reviews only" using the logged-in user's ID rather than the ID of the user whose page it is (editors can view any user's reviews page)
- Adds tests for all scopes but creation date (TBA)

the distinction between "open" and "unpublished" might need to be more consistent, currently it is:

- "Review log": All unpublished songs (i.e., the status is not published, but can be closed). 
- "Unpublished only": All open songs by user.
- "Pending reviews by user": All open songs by user. 

for writers probably open only is the most useful; for editors it could go either way?