### PR TITLE
Adds Redis/Sidekiq; prevents concurrent editing of reviews by two people

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem "pundit"
 
 gem "net-http"
 
+gem "sidekiq"
+
 gem "acts_as_list"
 
 gem "sortablejs-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -80,4 +80,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem 'mock_redis', '~> 0.13.2'
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -30,6 +30,12 @@ class ReviewsController < ApplicationController
   def edit
     @review = Review.find(params[:id])
     authorize @review
+    if @review.can_edit?(current_user.name)
+      @review.lock!(current_user.name)
+    else
+      flash[:notice] = "This review is being edited by #{@review.current_editor} and is currently locked."
+      redirect_to root_path
+    end 
   end
   
   def update
@@ -37,6 +43,7 @@ class ReviewsController < ApplicationController
     authorize review
     if review.update(review_params)
       @song.update_score!
+      review.unlock!
       flash[:notice] = "Updated review."
       if policy(Review).index?
         redirect_to @song

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,3 +4,10 @@ import "controllers"
 
 import "trix"
 import "@rails/actiontext"
+
+document.addEventListener("turbo:frame-missing", event => {
+  if (event.detail.response.redirected) {
+    event.preventDefault()
+    event.detail.visit(event.detail.response)
+  }
+})

--- a/app/jobs/expire_edit_lock_job.rb
+++ b/app/jobs/expire_edit_lock_job.rb
@@ -1,0 +1,10 @@
+class ExpireEditLockJob < ApplicationJob
+  queue_as :default
+
+  def perform(review_id)
+    review = Review.find(review_id)
+    if review.locked?
+      review.unlock!
+    end
+  end
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -26,6 +26,8 @@ class Review < ApplicationRecord
     self.user_id == id
   end
   
+  # All review lock methods use user's name rather than ID to prevent having to query the database again to display the user's name.
+  # Since we are not updating the user records in any way, nothing more is needed.
   def can_edit?(name)
     !self.locked? || self.current_editor == name
   end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -12,6 +12,8 @@ class Review < ApplicationRecord
   scope :by_created, -> { reorder(created_at: :asc) }
   scope :by_user, -> id { includes(:song, :user).where(user_id: id) }
 
+  EDIT_LOCK_TIMEOUT = 30
+
   def url_present?
     return self.url.present?
   end
@@ -24,4 +26,25 @@ class Review < ApplicationRecord
     self.user_id == id
   end
   
+  def can_edit?(name)
+    !self.locked? || self.current_editor == name
+  end
+  
+  def locked?
+    !!self.current_editor
+  end
+  
+  def lock!(name)
+    unless self.current_editor == name
+      self.current_editor = name
+      self.save
+      ExpireEditLockJob.set(wait: EDIT_LOCK_TIMEOUT.minutes).perform_later(self.id)
+    end    
+  end
+  
+  def unlock!
+    self.current_editor = nil
+    self.save
+  end
+
 end

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -66,7 +66,7 @@
           <% if policy(review).edit? && review.can_edit?(current_user.name) %>
 			     (<%= link_to "Edit this review", edit_review_path(review), data: { turbo_frame: dom_id(review) } %>)
           <% elsif policy(review).edit? && !review.can_edit?(current_user.name) %>
-            (Writer is editing review)
+            (<%= review.current_editor %> is editing)
           <% end %>
           <% if policy(review).destroy? %>
             (<%= link_to "Delete this review", review_path(review), :method => :delete, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %>)

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -63,9 +63,11 @@
             <% end %>
 		  <div class="review"></div>
           [<%= review.score %>]<br>
-          <% if policy(review).edit? %>
-			  (<%= link_to "Edit this review", edit_review_path(review), data: { turbo_frame: dom_id(review) } %>)
-         <% end %>
+          <% if policy(review).edit? && review.can_edit?(current_user.name) %>
+			     (<%= link_to "Edit this review", edit_review_path(review), data: { turbo_frame: dom_id(review) } %>)
+          <% elsif policy(review).edit? && !review.can_edit?(current_user.name) %>
+            (Writer is editing review)
+          <% end %>
           <% if policy(review).destroy? %>
             (<%= link_to "Delete this review", review_path(review), :method => :delete, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %>)
           <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module Blurber
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
+    config.active_job.queue_adapter = :sidekiq
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/db/migrate/20240314012322_add_current_editor_to_reviews.rb
+++ b/db/migrate/20240314012322_add_current_editor_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddCurrentEditorToReviews < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reviews, :current_editor, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_12_215520) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_14_012322) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_12_215520) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
+    t.string "current_editor"
     t.index ["song_id"], name: "index_reviews_on_song_id"
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end

--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,27 @@ databases:
     plan: free
 
 services:
+  - type: redis
+    name: sidekiq-redis
+    region: ohio
+    maxmemoryPolicy: noeviction
+    ipAllowList: [] # only allow internal connections
+
+  - type: worker
+    name: sidekiq-worker
+    runtime: ruby
+    region: ohio
+    buildCommand: bundle install
+    startCommand: bundle exec sidekiq
+    envVars:
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: sidekiq-redis
+          property: connectionString
+      - key: RAILS_MASTER_KEY
+        sync: false
+        
   - type: web
     name: blurber
     runtime: ruby
@@ -13,6 +34,11 @@ services:
     preDeployCommand: "./bin/rails db:migrate db:seed" 
     startCommand: "./bin/rails server"
     envVars:
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: sidekiq-redis
+          property: connectionString
       - key: DATABASE_URL
         fromDatabase:
           name: blurber

--- a/test/jobs/expire_edit_lock_job_test.rb
+++ b/test/jobs/expire_edit_lock_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ExpireEditLockJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -31,5 +31,20 @@ class ReviewTest < ActiveSupport::TestCase
     reviews = test_reviews.by_user(@user2.id)
     assert_equal(1, reviews.count)
   end
+  
+  test "review should be editable if no one is currenly editing it" do
+    @review1.current_editor = nil
+    assert @review1.can_edit?("Carly Rae Jepsen")
+  end
+  
+  test "review should not be editable if being edited by someone else" do
+    @review1.current_editor = "Carly Rae Jepsen"
+    refute @review1.can_edit?("Selena Gomez")
+  end
+  
+  test "review should be editable if being edited b oneself" do
+    @review1.current_editor = "Carly Rae Jepsen"
+    assert @review1.can_edit?("Carly Rae Jepsen")
+  end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "mock_redis"
+require "sidekiq/testing"
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
This is one of several quality of life changes to prevent work from being lost or overwritten, particularly around song closing times.

## Rationale:

### Situations we should prevent:

- We should prevent writers from submitting or editing blurbs for a song in Published state.

### Situations we would like to avoid:

- We would like to avoid writers submitting or editing blurbs for a song in Closed state.
- We would like to avoid writers losing their work while trying to submit a blurb for a song that closed/was published in the interim.
- We would like to avoid writers and editors overwriting each other's edits if they are editing a song at the same time.

### Functionality we would like to preserve/avoid:

- We would like editors to be able to edit and reorder blurbs for a song in Open state; this speeds up the editing process so it doesn't all have to be done in one sitting late at night.
- We would like to avoid a situation where a review is "checked out" or "locked" for editing, a writer forgets they have that tab open, and it remains locked indefinitely; we have writers in all time zones and can't rely on them being reminded to close it.

## Changes:

- A review can only be edited by one person at a time. 
- Once someone begins to edit a review (either inline or on a separate page), the review is locked for further editing.
- A review is unlocked after the user editing submits their changes or a timeout period expires. The edit lock timeout is currently set to 30 minutes. This can be adjusted depending on how things go in practice.

### Other changes:

- Adds Redis/Sidekiq to handle background jobs.
- Adds basic unit tests around locked/editable state and the existence of queued unlock jobs.

### Todo/known issues:

- There is no way (besides the console) of manually aborting edit lock when something goes wrong; this should be an admin tool.
- There is no indication that the edit lock timeout is 30 minutes, and no countdown or other notification for how long into the 30-minute time period things are.
- Turbo Frames (which inline editing uses), redirecting out of the frame, and displaying flash messages do not play nicely together. Currently I have sidestepped this issue by removing the edit link entirely if a review is locked. However, there is no automatic update at the moment, and editors will have to refresh the page for the edit link to show up again.
- Conversely, if a writer starts editing a review when an editor has the edit link available to them, we break out of the frame to redirect away from the song's view entirely. This uses the second hack [here](https://www.ducktypelabs.com/turbo-break-out-and-redirect/) -- it's not great but the third workaround adds more bulk to the controller than I would prefer. 
- Most importantly, there is nothing stopping a writer from submitting their edits (say) 60 minutes after starting, overwriting anything that happened in the intervening half-hour. We can check for diffs, but (in a running theme) this will become gnarlier with inline edit.