### PR TITLE
Fixes bug where reordering reviews creates phantom edit locks; fixes Render blueprint sync issue

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -31,7 +31,7 @@ class ReviewsController < ApplicationController
     @review = Review.find(params[:id])
     authorize @review
     if @review.can_edit?(current_user.name)
-      @review.lock!(current_user.name)
+      @review.edit_lock!(current_user.name)
     else
       flash[:notice] = "This review is being edited by #{@review.current_editor} and is currently locked."
       redirect_to root_path
@@ -43,7 +43,7 @@ class ReviewsController < ApplicationController
     authorize review
     if review.update(review_params)
       @song.update_score!
-      review.unlock!
+      review.edit_unlock!
       flash[:notice] = "Updated review."
       if policy(Review).index?
         redirect_to @song

--- a/app/jobs/expire_edit_lock_job.rb
+++ b/app/jobs/expire_edit_lock_job.rb
@@ -3,8 +3,8 @@ class ExpireEditLockJob < ApplicationJob
 
   def perform(review_id)
     review = Review.find(review_id)
-    if review.locked?
-      review.unlock!
+    if review.edit_locked?
+      review.edit_unlock!
     end
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -29,14 +29,14 @@ class Review < ApplicationRecord
   # All review lock methods use user's name rather than ID to prevent having to query the database again to display the user's name.
   # Since we are not updating the user records in any way, nothing more is needed.
   def can_edit?(name)
-    !self.locked? || self.current_editor == name
+    !self.edit_locked? || self.current_editor == name
   end
   
-  def locked?
+  def edit_locked?
     !!self.current_editor
   end
   
-  def lock!(name)
+  def edit_lock!(name)
     unless self.current_editor == name
       self.current_editor = name
       self.save
@@ -44,7 +44,7 @@ class Review < ApplicationRecord
     end    
   end
   
-  def unlock!
+  def edit_unlock!
     self.current_editor = nil
     self.save
   end

--- a/render.yaml
+++ b/render.yaml
@@ -2,19 +2,16 @@ databases:
   - name: blurber
     databaseName: blurber
     user: blurber
-    plan: free
 
 services:
   - type: redis
     name: sidekiq-redis
-    region: ohio
     maxmemoryPolicy: noeviction
     ipAllowList: [] # only allow internal connections
 
   - type: worker
     name: sidekiq-worker
     runtime: ruby
-    region: ohio
     buildCommand: bundle install
     startCommand: bundle exec sidekiq
     envVars:

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -53,13 +53,13 @@ class ReviewTest < ActiveSupport::TestCase
   end
   
   test "locking a review should create an edit unlock job if nobody is editing" do
-    @review1.lock!("Carly Rae Jepsen")
+    @review1.edit_lock!("Carly Rae Jepsen")
     assert_equal(@previous_queue_size + 1, Sidekiq::Worker.jobs.size) 
   end
   
   test "locking a review should not create an edit unlock job if there is already someone editing" do
     @review1.current_editor = "Carly Rae Jepsen"
-    @review1.lock!("Carly Rae Jepsen")
+    @review1.edit_lock!("Carly Rae Jepsen")
     assert_equal(@previous_queue_size, Sidekiq::Worker.jobs.size) 
   end 
   


### PR DESCRIPTION
Cause: Reordering reviews with acts_as_list calls ActiveRecord's `lock!` method, which was inadvertently redefined by me in the Review model, causing reviews to be locked for editing (with the supposed editor name "t") when they should not be.