### PR TITLE
Upgrades Redis to hopefully fix edit lock enqueueing issues, enables Sidekiq web interface to monitor all this

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,8 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
-# Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+# Use Redis adapter to run Action Cable in production; our Sidekiq version requires at least 6.2.0
+# gem "redis", ">= 6.2.0"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   resources :reviews
   resources :announcements
@@ -28,6 +30,10 @@ Rails.application.routes.draw do
 
   match '/songs/:id/wp' => 'songs#wp', :as => 'wp_song', :via => [:post]
   match '/reviews/:id/move' => 'reviews#move', :as => 'move', :via => [:patch]
+
+  authenticate :user, lambda { |u| u.admin? } do
+    mount Sidekiq::Web => "/sidekiq"
+  end
 
   get '*a' => redirect { |p, req| req.flash[:alert] = "Invalid URL."; '/' }, constraints: lambda { |req|
     req.path.exclude? 'rails/active_storage' }


### PR DESCRIPTION
Fixes #24. (hopefully)

Edit unlock jobs were being correctly created and scheduled in Sidekiq, but never enqueued, due to dependency issues with the Redis version; as a result jobs piled up in limbo, unable to be accessed or deleted through the web interface (deleting through the console worked). This resulted in blurbs being locked indefinitely for further editing unless the edit lock was manually cleared.

This also presumably fixes the error with the concurrent blurbing notification feature that is why it isn't live yet.