### PR TITLE
Adds notifications to editors before closing songs if writers are currently blurbing that song.

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -10,6 +10,7 @@ class ReviewsController < ApplicationController
   def new
     authorize Review
     @song = Song.find(params[:song_id])
+    @song.register_blurbing_session(current_user)
     @review = @song.reviews.build
   end
   
@@ -19,6 +20,7 @@ class ReviewsController < ApplicationController
     @review = @song.reviews.build(review_params)
     @review.user = current_user
     if @review.save
+      @song.end_blurbing_session
       @song.update_score!
       flash[:notice] = "Added review!"
       redirect_to root_path

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -4,7 +4,7 @@ class SongsController < ApplicationController
   def index
     authorize Song
     @songs = Song.list_available(policy_scope(Song.by_created), current_user)
-	@announcement = Announcement.find(1)
+	  @announcement = Announcement.find(1)
   end
   
   def show
@@ -20,7 +20,6 @@ class SongsController < ApplicationController
   def create
     authorize Song
     @song = Song.new(song_params)
-    @song.status = 0
     if @song.save
       flash[:notice] = "Added song!"
       redirect_to action: :index

--- a/app/javascript/controllers/confirmations_controller.js
+++ b/app/javascript/controllers/confirmations_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { blurbers: String };
+  
+  async blurber_confirmation(event) { 
+    if (!this.blurbersValue) {
+      return;
+    }
+    const blurbersMsg = `Are you sure? The following writers are blurbing: ${this.blurbersValue}`;
+    if (!window.confirm(blurbersMsg)) {
+      event.preventDefault();
+    }
+  }
+  
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -23,7 +23,6 @@ export default class extends Controller {
   async end(event) {
     const request = new FetchRequest('patch', `/reviews/${event.item.dataset.id}/move`, { query: {oldIndex: event.oldIndex, newIndex: event.newIndex}});
     const response = await request.perform()
-    console.log(response)
   }
 
 }

--- a/app/jobs/expire_blurbing_session_job.rb
+++ b/app/jobs/expire_blurbing_session_job.rb
@@ -1,0 +1,10 @@
+class ExpireBlurbingSessionJob < ApplicationJob
+  queue_as :default
+
+  def perform(session_id)
+    session = ActiveBlurbing.find(session_id)
+    if session
+      session.destroy
+    end
+  end
+end

--- a/app/models/active_blurbing.rb
+++ b/app/models/active_blurbing.rb
@@ -1,0 +1,32 @@
+class ActiveBlurbing < ApplicationRecord
+  belongs_to :song
+  after_create :set_timeout
+  
+  scope :by_song, -> id { includes(:song).where(song_id: id) }
+  
+  WARNING_NOTIFICATION_TIMEOUT = 30
+  
+  def self.currently_blurbing?(blurber, song)
+    self.exists?(:blurber => blurber, :song => song)
+  end
+
+  def self.create_blurbing_session(blurber, song)
+    unless self.currently_blurbing?(blurber, song)
+      ActiveBlurbing.create(blurber: blurber, song: song)
+    end
+  end
+  
+  # todo: this does not account for multiple blurbing sessions by a writer on a song (shouldn't happen, but...)
+  def self.end_blurbing_session(blurber, song)
+    session = self.find_by(:blurber => blurber, :song => song)
+    if session 
+      session.destroy
+    end
+  end
+  
+  private
+  
+  def set_timeout
+    ExpireBlurbingSessionJob.set(wait: WARNING_NOTIFICATION_TIMEOUT.minutes).perform_later(self.id)
+  end
+end

--- a/app/models/concerns/schedulable.rb
+++ b/app/models/concerns/schedulable.rb
@@ -1,0 +1,39 @@
+# Currently, this only handles determining what month a song will run upon creation.
+# Ex: If a song is added April 12, it is assumed it will run in May.
+# (We can't assume it's the next month always though -- May 2024's first post date is May 6, so if we add a song May 1, that's still a May song.)
+# If we go to a more frequent posting schedule this concern will do more.
+
+require "active_support/concern"
+
+module Schedulable
+  extend ActiveSupport::Concern
+  
+  # default argument is for test purposes
+  def self.current_posting_month(today = Date.today)
+    # todo: see whether ActiveSupport can simplify this mess more
+    second_monday = self.first_monday_of_month(today).next_week
+    posting_month = today >= second_monday ? today.next_month : today
+    posting_year = today.month == 12 && posting_month.month == 1 ? today.next_year.year : today.year
+    self.month_name(posting_month) + " " + posting_year.to_s
+  end
+
+  def self.next_posting_month(today = Date.today)
+    first_monday = self.first_monday_of_month(today)
+    posting_month = today > first_monday ? today.next_month : today
+    posting_year = today.month == 12 && posting_month.month == 1 ? today.next_year.year : today.year
+    self.month_name(posting_month) + " " + posting_year.to_s
+  end
+  
+  private
+  
+  def self.first_monday_of_month(day)
+    day_one = day.beginning_of_month
+    day_one += 1.days until day_one.wday == 1
+    day_one
+  end
+  
+  def self.month_name(date)
+    Date::MONTHNAMES[date.month]
+  end
+
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -26,6 +26,8 @@ class Review < ApplicationRecord
     self.user_id == id
   end
   
+  # Review lock methods
+  
   # All review lock methods use user's name rather than ID to prevent having to query the database again to display the user's name.
   # Since we are not updating the user records in any way, nothing more is needed.
   def can_edit?(name)
@@ -40,7 +42,8 @@ class Review < ApplicationRecord
     unless self.current_editor == name
       self.current_editor = name
       self.save
-      ExpireEditLockJob.set(wait: EDIT_LOCK_TIMEOUT.minutes).perform_later(self.id)
+      # todo: pass model rather than ID?
+      ExpireEditLockJob.set(wait: EDIT_LOCK_TIMEOUT.seconds).perform_later(self.id)
     end    
   end
   

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -43,7 +43,7 @@ class Review < ApplicationRecord
       self.current_editor = name
       self.save
       # todo: pass model rather than ID?
-      ExpireEditLockJob.set(wait: EDIT_LOCK_TIMEOUT.seconds).perform_later(self.id)
+      ExpireEditLockJob.set(wait: EDIT_LOCK_TIMEOUT.minutes).perform_later(self.id)
     end    
   end
   

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -76,6 +76,14 @@ class Song < ApplicationRecord
     end
     true
   end
+  
+  def register_blurbing_session(blurber)
+    ActiveBlurbing.create_blurbing_session(blurber.name, self)
+  end
+  
+  def current_blurbers
+    ActiveBlurbing.by_song(self.id).pluck(:blurber).join(", ")
+  end
 
   private  
   

--- a/app/services/formatter_service.rb
+++ b/app/services/formatter_service.rb
@@ -6,9 +6,11 @@ class FormatterService
   end
   
   def self.generate_post_frame(song, subhead, image_link)
-    alt = song.alttext ? song.alttext : "#{song.artist} - #{song.title}"
+    alt = song.alttext && song.alttext != "" ? song.alttext : "#{song.artist} - #{song.title}"
+    score = song.score ? sprintf('%.2f', song.score) : "N/A" 
+    controversy = song.controversy ? sprintf('%.2f', song.controversy) : "N/A" 
     post_html = "<p><i>#{subhead}</i></p><center><img src= '#{image_link}' alt = '#{alt}' border = 2><br><b>[<a href='#{song.video}'>Video</a>]"
-    post_html += "<BR><a title='Controversy index: #{sprintf('%.2f', song.controversy)}'>[#{sprintf('%.2f', song.score)}]</a></b></center></p>"
+    post_html += "<BR><a title='Controversy index: #{controversy}'>[#{score}]</a></b></center></p>"
   end
 
   def self.generate_review(review)

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -2,10 +2,14 @@
   <h4>
   <%= button_to "Edit song info", edit_song_path(@song.id),  { :method => "get" } %>
   <% if @song.open? %>
-    <%= button_to "Close song for editing", song_path(song: { status: "closed" }), { method: :patch, form: { data: { turbo: true } } } %>  
+    <%= button_to "Close song for editing", song_path(song: { status: "closed" }), 
+      { method: :patch, form: { data: { turbo: true, controller: "confirmations", 
+        action: "submit->confirmations#blurber_confirmation", confirmations_blurbers_value: @song.current_blurbers } 
+      } } 
+    %> 
   <% else if @song.closed? %>
     <%= button_to "Reopen song", song_path(song: { status: "open" }), { method: :patch, form: { data: { turbo: true } } } %>  
-    <%= form_with url: wp_song_path, method: :post, data: { turbo: true } do |form| %>
+    <%= form_with url: wp_song_path, method: :post, data: { turbo: true } do |form| %>s
 	    <div>
           <%= form.label "Schedule post at (GMT):" %>
           <%= form.text_field :post_time,
@@ -59,12 +63,12 @@
     <%  @song.reviews.each do |review| %>
         <li data-id ="<%= review.id %>">
 	        <%= turbo_frame_tag "review_#{review.id}", target: "_top" do %>
-              <strong><a href="<%= review.user.url %>" target="_blank"><%= review.user.name %>:</strong></a> <%= sanitize review.content %>
-            <% end %>
+            <strong><a href="<%= review.user.url %>" target="_blank"><%= review.user.name %>:</strong></a> <%= sanitize review.content %>
+          <% end %>
 		  <div class="review"></div>
           [<%= review.score %>]<br>
           <% if policy(review).edit? && review.can_edit?(current_user.name) %>
-			     (<%= link_to "Edit this review", edit_review_path(review), data: { turbo_frame: dom_id(review) } %>)
+			      (<%= link_to "Edit this review", edit_review_path(review), data: { turbo_frame: dom_id(review) } %>)
           <% elsif policy(review).edit? && !review.can_edit?(current_user.name) %>
             (<%= review.current_editor %> is editing)
           <% end %>

--- a/db/migrate/20240412184235_add_month_year_to_songs.rb
+++ b/db/migrate/20240412184235_add_month_year_to_songs.rb
@@ -1,0 +1,5 @@
+class AddMonthYearToSongs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :songs, :month_year, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_14_012322) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_12_184235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_14_012322) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
+  create_table "active_blurbings", force: :cascade do |t|
+    t.string "blurber"
+    t.bigint "song_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["song_id"], name: "index_active_blurbings_on_song_id"
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -82,6 +90,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_14_012322) do
     t.decimal "score"
     t.decimal "controversy"
     t.string "alttext"
+    t.string "month_year"
   end
 
   create_table "users", force: :cascade do |t|
@@ -103,6 +112,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_14_012322) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "active_blurbings", "songs"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "reviews", "songs"

--- a/render.yaml
+++ b/render.yaml
@@ -27,7 +27,6 @@ services:
     name: blurber
     runtime: ruby
     plan: free
-    region: ohio
     buildCommand: "./bin/render-build.sh"
     preDeployCommand: "./bin/rails db:migrate db:seed" 
     startCommand: "./bin/rails server"

--- a/test/fixtures/active_blurbings.yml
+++ b/test/fixtures/active_blurbings.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/jobs/expire_blurbing_session_job_test.rb
+++ b/test/jobs/expire_blurbing_session_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ExpireBlurbingSessionJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/active_blurbing_test.rb
+++ b/test/models/active_blurbing_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class ActiveBlurbingTest < ActiveSupport::TestCase
+
+  def setup
+    @previous_queue_size = Sidekiq::Worker.jobs.size # we can't rely on the queue being empty because ActiveStorage enqueues some jobs
+    @user1 = User.create!(username: "Redfoo", name: "redfoo", url: "", password_confirmation: "partyrock") 
+    @song1 = Song.create!(title: "Party Rock Anthem", artist: "LMFAO", status: "open", video: "", score: 0, controversy: 0)
+  end
+  
+  test "by_song scope should include the correct number of results for a song with active blurbings" do
+    @user2 = User.create!(username: "Skyblu", name: "skyblu", url: "", password_confirmation: "partyrock")     
+    @song2 = Song.create!(title: "Like a G6", artist: "Far East Movement ft. The Cataracs and Dev", status: "open", video: "", score: 0, controversy: 0)
+    @blurbing1 = ActiveBlurbing.create!(blurber: @user1, song: @song1)
+    @blurbing2 = ActiveBlurbing.create!(blurber: @user2, song: @song1)
+    @blurbing3 = ActiveBlurbing.create!(blurber: @user1, song: @song2)
+    test_blurbings = ActiveBlurbing.where(id: [@song1.id, @song2.id])
+    blurbings = ActiveBlurbing.by_song(@song1.id)
+    assert_equal(2, blurbings.count)  
+  end
+
+  test "by_song scope should include no results for a song with no active blurbings" do
+    blurbings  = ActiveBlurbing.by_song(@song1.id)
+    assert_equal(0, blurbings.count)  
+  end
+  
+  test "successfully creating a blurbing session should schedule an expire job" do
+    @blurbing = ActiveBlurbing.create!(blurber: @user1, song: @song1)
+    assert_equal(@previous_queue_size + 1, Sidekiq::Worker.jobs.size) 
+  end
+ 
+   def teardown
+    # todo: as before look into whether clearing the whole queue here causes issues in other tests
+    Sidekiq::Worker.clear_all
+  end
+ 
+end

--- a/test/models/song_test.rb
+++ b/test/models/song_test.rb
@@ -110,21 +110,21 @@ end
 class SchedulableTest < ActiveSupport::TestCase
 
   test "the current posting month come the second Monday of November is December" do
-    month = Schedulable.next_posting_month(Date.new(2024, 11, 11))
+    month = Schedulable.current_posting_month(Date.new(2024, 11, 11))
     assert_equal("December 2024", month)
   end  
 
-  test "the current posting month before the second Monday of December is that December" do
-    month = Schedulable.next_posting_month(Date.new(2024, 12, 1))
+  test "the current posting month in the first week of December is that December" do
+    month = Schedulable.current_posting_month(Date.new(2024, 12, 3))
     assert_equal("December 2024", month)
   end
   
   test "the current posting month come the second Monday of December is the next January" do
-    month = Schedulable.next_posting_month(Date.new(2024, 12, 9))
+    month = Schedulable.current_posting_month(Date.new(2024, 12, 9))
     assert_equal("January 2025", month)
   end
 
-  test "the current posting month after the first Monday of November is December" do
+  test "the next posting month after the first Monday of November is December" do
     month = Schedulable.next_posting_month(Date.new(2024, 11, 5))
     assert_equal("December 2024", month)
   end  

--- a/test/models/song_test.rb
+++ b/test/models/song_test.rb
@@ -105,3 +105,37 @@ class CollateBlurbTest < ActiveSupport::TestCase
     assert_equal(expected_post, song.generate_html)
   end
 end
+
+# todo: this is a concern, so tests for it should probably not be here
+class SchedulableTest < ActiveSupport::TestCase
+
+  test "the current posting month come the second Monday of November is December" do
+    month = Schedulable.next_posting_month(Date.new(2024, 11, 11))
+    assert_equal("December 2024", month)
+  end  
+
+  test "the current posting month before the second Monday of December is that December" do
+    month = Schedulable.next_posting_month(Date.new(2024, 12, 1))
+    assert_equal("December 2024", month)
+  end
+  
+  test "the current posting month come the second Monday of December is the next January" do
+    month = Schedulable.next_posting_month(Date.new(2024, 12, 9))
+    assert_equal("January 2025", month)
+  end
+
+  test "the current posting month after the first Monday of November is December" do
+    month = Schedulable.next_posting_month(Date.new(2024, 11, 5))
+    assert_equal("December 2024", month)
+  end  
+  
+  test "the next posting month before the first Monday of December is that December" do
+    month = Schedulable.next_posting_month(Date.new(2024, 12, 1))
+    assert_equal("December 2024", month)
+  end
+  
+  test "the next posting month after the first Monday of December is the next January" do
+    month = Schedulable.next_posting_month(Date.new(2024, 12, 3))
+    assert_equal("January 2025", month)
+  end
+end


### PR DESCRIPTION
When a writer enters the submit blurb page on a song, a blurbing session is created for that user and that song. Upon creation, a timeout job is scheduled for 30 minutes later to automatically expire the blurbing session and destroy its record. Submitting the blurb will end the session as well.

Unlike edit locks, editors are still able to close a song if there are writers blurbing, they just receive a confirmation popup first, telling them who those writers are, so they can ask them about ETA, etc. 

Known issues:

- If a writer is blurbing a song, the button will display an alert that they're still blurbing even after the blurbing session expires/they've submitted their blurb, until the song view is reloaded, because the Stimulus controller still has the old data from `current_blurbers`. In practice a lot of things will refresh that page (reordering, editing), however, but ideally this should be kept up to date.
- It shouldn't be possible for a writer to have two blurbing sessions for the same song, but if that does happen, there should be better handling of that situation to prevent them hanging around indefinitely.

Other changes:

- Wrote (very) basic unit tests for the ActiveBlurbing model.
- Fixed oversight where closing a song with 0 reviews throws an error because it's expecting score/controversy numbers.
- Presumably fixes the issue with default alt text generating, but need to check on the site.
- Cleaned up Stimulus controller files.