### PR TITLE
Adds posting month to song model; filters song index by current month.

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -4,7 +4,7 @@ class SongsController < ApplicationController
   def index
     authorize Song
     @songs = Song.list_available(policy_scope(Song.by_created), current_user)
-	@announcement = Announcement.find(1)
+	  @announcement = Announcement.find(1)
   end
   
   def show
@@ -20,7 +20,6 @@ class SongsController < ApplicationController
   def create
     authorize Song
     @song = Song.new(song_params)
-    @song.status = 0
     if @song.save
       flash[:notice] = "Added song!"
       redirect_to action: :index

--- a/app/models/concerns/schedulable.rb
+++ b/app/models/concerns/schedulable.rb
@@ -1,0 +1,39 @@
+# Currently, this only handles determining what month a song will run upon creation.
+# Ex: If a song is added April 12, it is assumed it will run in May.
+# (We can't assume it's the next month always though -- May 2024's first post date is May 6, so if we add a song May 1, that's still a May song.)
+# If we go to a more frequent posting schedule this concern will do more.
+
+require "active_support/concern"
+
+module Schedulable
+  extend ActiveSupport::Concern
+  
+  # default argument is for test purposes
+  def self.current_posting_month(today = Date.today)
+    # todo: see whether ActiveSupport can simplify this mess more
+    second_monday = self.first_monday_of_month(today).next_week
+    posting_month = today >= second_monday ? today.next_month : today
+    posting_year = today.month == 12 && posting_month.month == 1 ? today.next_year.year : today.year
+    self.month_name(posting_month) + " " + posting_year.to_s
+  end
+
+  def self.next_posting_month(today = Date.today)
+    first_monday = self.first_monday_of_month(today)
+    posting_month = today > first_monday ? today.next_month : today
+    posting_year = today.month == 12 && posting_month.month == 1 ? today.next_year.year : today.year
+    self.month_name(posting_month) + " " + posting_year.to_s
+  end
+  
+  private
+  
+  def self.first_monday_of_month(day)
+    day_one = day.beginning_of_month
+    day_one += 1.days until day_one.wday == 1
+    day_one
+  end
+  
+  def self.month_name(date)
+    Date::MONTHNAMES[date.month]
+  end
+
+end

--- a/db/migrate/20240412184235_add_month_year_to_songs.rb
+++ b/db/migrate/20240412184235_add_month_year_to_songs.rb
@@ -1,0 +1,5 @@
+class AddMonthYearToSongs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :songs, :month_year, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_14_012322) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_12_184235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_14_012322) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
+  create_table "active_blurbings", force: :cascade do |t|
+    t.string "blurber"
+    t.bigint "song_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["song_id"], name: "index_active_blurbings_on_song_id"
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -82,6 +90,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_14_012322) do
     t.decimal "score"
     t.decimal "controversy"
     t.string "alttext"
+    t.string "month_year"
   end
 
   create_table "users", force: :cascade do |t|
@@ -103,6 +112,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_14_012322) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "active_blurbings", "songs"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "reviews", "songs"

--- a/test/models/song_test.rb
+++ b/test/models/song_test.rb
@@ -105,3 +105,37 @@ class CollateBlurbTest < ActiveSupport::TestCase
     assert_equal(expected_post, song.generate_html)
   end
 end
+
+# todo: this is a concern, so tests for it should probably not be here
+class SchedulableTest < ActiveSupport::TestCase
+
+  test "the current posting month come the second Monday of November is December" do
+    month = Schedulable.next_posting_month(Date.new(2024, 11, 11))
+    assert_equal("December 2024", month)
+  end  
+
+  test "the current posting month before the second Monday of December is that December" do
+    month = Schedulable.next_posting_month(Date.new(2024, 12, 1))
+    assert_equal("December 2024", month)
+  end
+  
+  test "the current posting month come the second Monday of December is the next January" do
+    month = Schedulable.next_posting_month(Date.new(2024, 12, 9))
+    assert_equal("January 2025", month)
+  end
+
+  test "the current posting month after the first Monday of November is December" do
+    month = Schedulable.next_posting_month(Date.new(2024, 11, 5))
+    assert_equal("December 2024", month)
+  end  
+  
+  test "the next posting month before the first Monday of December is that December" do
+    month = Schedulable.next_posting_month(Date.new(2024, 12, 1))
+    assert_equal("December 2024", month)
+  end
+  
+  test "the next posting month after the first Monday of December is the next January" do
+    month = Schedulable.next_posting_month(Date.new(2024, 12, 3))
+    assert_equal("January 2025", month)
+  end
+end


### PR DESCRIPTION
This is scaffolding for implementing tabbing by month. Changes:

- Song model now has a `month_year` column. This is a string of the form "April 2024" -- the full date is probably too granular when we're only posting on a monthly basis. If we move to a more frequent posting schedule this can be revisited.
- Added a new Schedulable concern to determine posting months based on the current day. This is probably more complex than it really needs to be but:
- - The "current posting month" is used for view filtering: editors by default only see songs for the upcoming month. Today, on April 17, that would be May 2024. It will continue to be May 2024 until the second week of May (i.e., when we're done with May's songs and have moved on to June)
- - The "next posting month" is similar, but used when creating new songs to automatically set its month and year. As such the cutoff is the first week of May, so if an editor adds a song on May 7, its month/year will be June 2024.
- - There are tests for this but this may uh end up being revisited in May.

Songs in the blurber need to be retroactively updated with their months, fortunately, that is not too many at this point.